### PR TITLE
Add api plugins support and sdb plugin

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,6 @@
 # can be defined on a task by task basis
 monitor_timeout: 15
-resources: resources.yaml
+resources: config/resources.yaml
 region: us-east-1
 results_topic: nymms_results
 tasks_queue: nymms_tasks
@@ -18,10 +18,14 @@ scheduler:
   interval: 60
   backend: nymms.scheduler.backends.yaml_backend.YamlBackend
   backend_args:
-    path: nodes.yaml
+    path: config/nodes.yaml
 
 reactor:
   queue_wait_time: 20
   visibility_timeout: 30
   queue_name: reactor_queue
-  handler_config_path: handlers
+  handler_config_path: config/handlers
+
+api:
+  plugins:
+  - nymms.api.plugins.sdb_handler

--- a/nymms/api/plugins/sdb_handler.py
+++ b/nymms/api/plugins/sdb_handler.py
@@ -1,0 +1,41 @@
+import logging
+import arrow
+
+from flask import request
+
+from nymms import schemas
+from nymms.api import routes
+from nymms.config import config
+from nymms.providers.sdb import SimpleDBBackend
+
+
+logger = logging.getLogger(__name__)
+logger.debug('imported API plugin: %s', __name__)
+
+
+@routes.nymms_api.route('/result', methods=['GET'])
+def result():
+    """
+    List past results.
+
+    Query Params:
+    - limit (default 1000)
+    - from_timestamp
+    - to_timestamp
+    """
+    region = config.settings['region']
+    domain_name = config.settings['result_domain']
+    backend = SimpleDBBackend(region, domain_name)
+    args = request.args.to_dict(flat=True)
+    limit = int(args.pop('limit', routes.DEFAULT_RESULT_LIMIT))
+    from_timestamp = args.pop('from_timestamp', None)
+    to_timestamp = args.pop('to_timestamp', None)
+    filters = []
+    if from_timestamp:
+        filters.append(
+            'timestamp >= "%s"' % arrow.get(from_timestamp))
+    if to_timestamp:
+        filters.append(
+            'timestamp <= "%s"' % arrow.get(to_timestamp).timestamp)
+    results, _ = backend.filter(filters=filters, max_items=limit)
+    return [schemas.APIResult(r).to_primitive(role='sdb') for r in results]

--- a/nymms/api/routes.py
+++ b/nymms/api/routes.py
@@ -11,7 +11,6 @@ from nymms.state import sdb_state
 from nymms.suppress import sdb_suppress
 from nymms.config import config
 from nymms import schemas
-from nymms.providers.sdb import SimpleDBBackend
 
 
 logger = logging.getLogger(__name__)
@@ -43,37 +42,6 @@ def state():
         filters=request.args,
         max_items=limit)
     return [s.to_primitive() for s in states]
-
-
-# Disabling for now- need a way of adding optional API endpoints
-# For example, this end point would only work if the SDB results handler
-# was enabled
-# @nymms_api.route('/result', methods=['GET'])
-def result():
-    """
-    List past results.
-
-    Query Params:
-    - limit (default 1000)
-    - from_timestamp
-    - to_timestamp
-    """
-    region = config.settings['region']
-    domain_name = config.settings['result_domain']
-    backend = SimpleDBBackend(region, domain_name)
-    args = request.args.to_dict(flat=True)
-    limit = int(args.pop('limit', DEFAULT_RESULT_LIMIT))
-    from_timestamp = args.pop('from_timestamp', None)
-    to_timestamp = args.pop('to_timestamp', None)
-    filters = []
-    if from_timestamp:
-        filters.append(
-            'timestamp >= "%s"' % arrow.get(from_timestamp))
-    if to_timestamp:
-        filters.append(
-            'timestamp <= "%s"' % arrow.get(to_timestamp).timestamp)
-    results, _ = backend.filter(filters=filters, max_items=limit)
-    return [schemas.APIResult(r).to_primitive() for r in results]
 
 
 @nymms_api.route('/suppress', methods=['GET', 'POST'])

--- a/nymms/reactor/handlers/sdb_handler.py
+++ b/nymms/reactor/handlers/sdb_handler.py
@@ -48,7 +48,7 @@ class SDBHandler(Handler):
         # only persist alert states
         if result.state in (STATE_OK,):
             return item_name
-        self.domain.put_attributes(item_name, result.to_primitive())
+        self.domain.put_attributes(item_name, result.to_primitive(role='sdb'))
         logger.debug("Added %s to %s", item_name, self.domain_name)
         return item_name
 

--- a/nymms/schemas/__init__.py
+++ b/nymms/schemas/__init__.py
@@ -8,6 +8,7 @@ from nymms.schemas.types import (TimestampType, StateType, StateTypeType,
                                  JSONType, StateNameType, StateTypeNameType)
 
 from schematics.models import Model
+from schematics.transforms import blacklist
 from schematics.types import (
     StringType, IPv4Type, UUIDType, IntType)
 import arrow
@@ -120,6 +121,9 @@ class Result(StateModel, OriginModel):
     timestamp = TimestampType(default=arrow.get)
     output = StringType()
     task_context = JSONType()
+
+    class Options:
+        roles = {'sdb': blacklist('task_context')}
 
 
 class APIResult(Result):

--- a/scripts/nymms_api
+++ b/scripts/nymms_api
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import importlib
+
 from nymms.config import config
 from nymms.utils import cli
 
@@ -10,4 +12,8 @@ logger = cli.setup_logging(args.verbose)
 config.load_config(args.config)
 
 from nymms.api import routes
+
+for plugin in config.settings.get('api', []).get('plugins', []):
+    importlib.import_module(plugin)
+
 routes.nymms_api.run(debug=True)


### PR DESCRIPTION
Allow the optional addition of the sdb handler plugin for the
nymms API.

Also squash the task_context when saving results.  The task_context
can be large and causes errors when saving to SDB.