### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,4 +39,4 @@ Optionally:
   pagerduty reactor handler
 
 .. _`boto pull request`: https://github.com/boto/boto/pull/1414
-.. _`ReadTheDocs`: http://nymms.readthedocs.org/en/latest/
+.. _`ReadTheDocs`: https://nymms.readthedocs.io/en/latest/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.